### PR TITLE
Escape special characters in the description attribute of meta tag.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
 			<artifactId>forms_rt</artifactId>
 			<version>7.0.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/grabber/formats/EPUB.java
+++ b/src/main/java/grabber/formats/EPUB.java
@@ -20,6 +20,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 /**
  * Handles the creation of the EPUB file.
  */
@@ -66,8 +68,11 @@ public class EPUB {
             builder.append("<title>" + novelMetadata.getTitle() + "</title>\n");
         if (!novelMetadata.getAuthor().isEmpty())
             builder.append("<meta name=\"author\" content=\"" + novelMetadata.getAuthor() + "\"></meta>\n");
-        if (!novelMetadata.getDescription().isEmpty())
-            builder.append("<meta name=\"description\" content=\"" + novelMetadata.getDescription() + "\"></meta>\n");
+        if (!novelMetadata.getDescription().isEmpty()) {
+            String escaped_meta_desc = 
+		StringEscapeUtils.escapeHtml4(novelMetadata.getDescription());
+            builder.append("<meta name=\"description\" content=\"" + escaped_meta_desc + "\"></meta>\n");
+        }
         builder.append("<meta name=\"url\" content=\"" + novel.novelLink + "\"></meta>\n");
         builder.append("<meta name=\"copyright\" content=\"This EPUB is for private use only.\"></meta>\n");
         builder.append("<meta name=\"generator\" content=\"Novel-Grabber " + init.versionNumber + "\"></meta>\n");


### PR DESCRIPTION
This patch is to escape special characters in the description attribute of the meta tag of the EPUB.

Without this patch,  if the description has special characters like double-quotations, the Novel-Grabber generates broken meta tag records into  EPUBs. This causes "Specification mandate value for attribute xxx" errors on the iBook app in iOS, and it can never be shown on any pages. To reproduce this problem, try honeyfeed.fm/novels/7654.

