### PR TITLE
Fix image handling issues

### DIFF
--- a/src/main/java/grabber/Chapter.java
+++ b/src/main/java/grabber/Chapter.java
@@ -95,6 +95,7 @@ public class Chapter implements Serializable {
         for (Element image : chapterContainer.select("img")) {
             String imageURL = image.absUrl("src");
             String imageFilename = GrabberUtils.getFilenameFromUrl(imageURL);
+            String imageFileBasename = GrabberUtils.getFileBasename(imageFilename);
             BufferedImage bufferedImage = GrabberUtils.getImage(imageURL);
 
             if(bufferedImage != null) {
@@ -104,6 +105,9 @@ public class Chapter implements Serializable {
                 }
                 // Check if image has file extension. If not set as png.
                 if(GrabberUtils.getFileExtension(imageFilename) == null) imageFilename += ".png";
+                // If image already exists, rename it
+                while (images.containsKey(imageFilename))
+                    imageFilename = imageFileBasename + "_" + UUID.randomUUID().toString() + "." + GrabberUtils.getFileExtension(imageFilename);
                 // Modify href of image src to downloaded image
                 image.attr("src", imageFilename);
 

--- a/src/main/java/grabber/GrabberUtils.java
+++ b/src/main/java/grabber/GrabberUtils.java
@@ -98,6 +98,13 @@ public class GrabberUtils {
             return fileName.substring(fileName.lastIndexOf(".")+1);
         else return null;
     }
+    
+    public static String getFileBasename(String filename) {
+        String fileName = new File(filename).getName();
+        if(fileName.lastIndexOf(".") != -1)
+            return fileName.substring(0, fileName.lastIndexOf("."));
+        else return filename;
+    }
 
     static String getFileName(String imageName) {
         if (imageName != null && imageName.contains("/"))

--- a/src/main/java/grabber/Novel.java
+++ b/src/main/java/grabber/Novel.java
@@ -143,6 +143,7 @@ public class Novel {
         // Reset chapter numbering
         Chapter.chapterCounter = 0;
         chapterList = new ArrayList<>();
+        images = new HashMap<>();
         while (true) {
             // replace with actual interrupted
             if(killTask) {

--- a/src/main/java/gui/GUI.java
+++ b/src/main/java/gui/GUI.java
@@ -533,6 +533,7 @@ public class GUI extends JFrame {
                     manDownloadInProgress(true);
                     try {
                         manNovel.chapterList = new ArrayList<>();
+                        manNovel.images = new HashMap<>();
                         for (int i = 0; i < manLinkListModel.size(); i++) {
                             manNovel.chapterList.add(manLinkListModel.get(i));
                         }


### PR DESCRIPTION
When downloading a page or group of pages with several identically named images, the last image with that name will overwrite the previous ones. This pull fixes that by appending a random UUID to all duplicate images when downloading them.
It also fixes a situation where when running multiple manual downloads, the images from previous downloads are included in output files.